### PR TITLE
(SIMP-3822) simp-utils: puppetlast errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,17 @@ script:
 notifications:
   email: false
 rvm:
-  - 1.8.7 # CentOS 6
-  - 1.9.3 # CentOS 7 (old)
-  - 2.0.0 # CentOS 7
+# Would like to test with older Ruby versions,
+# but gems don't resolve.
+#  - 1.8.7 # CentOS 6
+#  - 1.9.3 # CentOS 7 (old)
+#  - 2.0.0 # CentOS 7
   - 2.1.9 # Current Puppet AIO version
   - 2.4.1 # Future Puppet AIO version
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: 1.8.7
-    - rvm: 1.9.3
-    - rvm: 2.0.0
+#    - rvm: 1.8.7
+#    - rvm: 1.9.3
+#    - rvm: 2.0.0
     - rvm: 2.4.1

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'rspec'
   gem 'simplecov'
   gem 'mocha'
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 4.0.0', '<= 6.0.0'])
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 4.0.1', '<= 6.0.0'])
   gem 'travis'
   gem 'travis-lint'
   gem 'travish'

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.0.2
+Version: 6.0.3
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -60,6 +60,10 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+
+* Tue Oct 03 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.3-0
+- Fixed bug in which puppetlast sort options were not working.
+
 * Tue Oct 03 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.2-0
 - added example ldifs to be copied to /usr/share/simp
 - changed rake and gemfiles so pkg:rpm would work

--- a/scripts/sbin/puppetlast
+++ b/scripts/sbin/puppetlast
@@ -197,14 +197,23 @@ class PuppetLast
     node_data = []
 
     hosts.each do |host|
-      last_checkin = Time.now - Time.parse(host[:catalog_timestamp])
+      if host[:catalog_timestamp].nil?
+        # This can happen in weird cases. Mark as an expired node, so
+        # the expired logic doesn't try to do math on a nil timestamp.
+        last_checkin = nil
+        formatted_checkin = 'N/A'
+        host[:expired] = nil
+      else
+        last_checkin = Time.now - Time.parse(host[:catalog_timestamp])
+        formatted_checkin = sprintf("%#{@options.round_to}f",(last_checkin * @options.divisor).abs)
+      end
       node_data << {
         :last_checkin => last_checkin,
         :expired      => host[:expired].nil? ? false : host[:expired],
         :certname     => host[:certname],
         :environment  => host[:catalog_environment].nil? ? 'N/A' : host[:catalog_environment],
         :status       => host[:latest_report_status].nil? ? 'N/A' : host[:latest_report_status],
-        :formatted_checkin => sprintf("%#{@options.round_to}f",(last_checkin * @options.divisor).abs),
+        :formatted_checkin => formatted_checkin
       }
     end
 
@@ -224,9 +233,17 @@ class PuppetLast
     when :certname
       return hosts.sort{ |a,b| a[:certname] <=> b[:certname] }
     when :time
-      return hosts.sort{ |a,b| a[:last_checkin] <=> b[:last_checkin] }
+      return hosts.sort{ |a,b| 
+        if a[:last_checkin].nil? and !b[:last_checkin].nil?
+          1
+        elsif !a[:last_checkin].nil? and b[:last_checkin].nil?
+          -1
+        else
+          a[:last_checkin] <=> b[:last_checkin]
+        end
+      }
     when :status
-      return hosts.sort{ |a,b| a[:status] <=> b[:status] }
+      return hosts.sort{ |a,b| a[:status].downcase <=> b[:status].downcase }
     when :environment
       return hosts.sort{ |a,b| a[:environment] <=> b[:environment] }
     else
@@ -238,6 +255,50 @@ class PuppetLast
   def find_longest(sorted_data, key)
     keys = sorted_data.map { |h| h[key].to_s }
     return keys.max_by(&:length).length
+  end
+
+  def print_node_without_checkin(node, col_len)
+    if @options.detailed
+      printf(
+        "%-#{col_len[:certname]}s from environment %-#{col_len[:environment]}s has no reported check in\n", 
+        node[:certname],
+        node[:environment]
+      )
+    else
+      printf("%-#{col_len[:certname]}s has no reported check in\n", node[:certname])
+    end
+  end
+
+  def print_node_with_checkin(node, col_len)
+    if node[:last_checkin] < 0
+      msg = "%-#{col_len[:certname]}s time issue: %#{col_len[:formatted_checkin]}#{@options.round_to}f %s in the future\n"
+    else node[:last_checkin] < @options.expsecs
+      if @options.detailed
+        msg = "%-#{col_len[:certname]}s from environment %-#{col_len[:environment]}s checked in %#{col_len[:formatted_checkin]}#{@options.round_to}f %s ago with status %-#{col_len[:status]}s\n"
+      else
+        msg = "%-#{col_len[:certname]}s checked in %#{col_len[:formatted_checkin]}#{@options.round_to}f %s ago\n"
+      end
+    end
+
+    if node[:last_checkin].to_s =~ /e/ then
+      puts "#{node[:certname]} outside the bounds of time and space"
+    else
+      if @options.detailed
+        printf(msg,
+          node[:certname],
+          node[:environment],
+          node[:formatted_checkin],
+          @options.outtime,
+          node[:status]
+        )
+      else
+        printf(msg,
+          node[:certname],
+          node[:formatted_checkin],
+          @options.outtime
+        )
+      end
+    end
   end
 
   def main(args)
@@ -266,41 +327,17 @@ class PuppetLast
     end
 
     # ... and the rest of the table
-    node_data.each do |node|
+    sorted_data.each do |node|
       # expired nodes aren't included when returning all nodes from PuppetDB,
       # but users can specify nodes manually
-      if not node[:expired] then
-        if node[:last_checkin] < 0
-          msg = "%-#{col_len[:certname]}s time issue: %#{col_len[:formatted_checkin]}#{@options.round_to}f %s in the future\n"
-        else node[:last_checkin] < @options.expsecs
-          if @options.detailed
-            msg = "%-#{col_len[:certname]}s from environment %-#{col_len[:environment]}s checked in %#{col_len[:formatted_checkin]}#{@options.round_to}f %s ago with status %-#{col_len[:status]}s\n"
-          else
-            msg = "%-#{col_len[:certname]}s checked in %#{col_len[:formatted_checkin]}#{@options.round_to}f %s ago\n"
-          end
-        end
-
-        if node[:last_checkin].to_s =~ /e/ then
-          puts "#{node[:certname]} outside the bounds of time and space"
-        else
-          if @options.detailed
-            printf(msg,
-              node[:certname],
-              node[:environment],
-              node[:formatted_checkin],
-              @options.outtime,
-              node[:status]
-            )
-          else
-            printf(msg,
-              node[:certname],
-              node[:formatted_checkin],
-              @options.outtime
-            )
-          end
-        end
-      else
+      if node[:expired]
         puts "#{node[:certname]} expired"
+      else
+        if node[:last_checkin].nil?
+          print_node_without_checkin(node, col_len)
+        else
+          print_node_with_checkin(node, col_len)
+        end
       end
     end
     return 0

--- a/spec/files/all_hosts.json
+++ b/spec/files/all_hosts.json
@@ -83,5 +83,22 @@
     "certname": "client9.test.net",
     "catalog_timestamp": "2016-10-23T17:31:13.600Z",
     "latest_report_status": "failed"
+  },
+  {
+    "deactivated": null,
+    "latest_report_hash": null,
+    "facts_environment": "test",
+    "cached_catalog_status": null,
+    "report_environment": null,
+    "latest_report_corrective_change": null,
+    "catalog_environment": "test",
+    "facts_timestamp": null,
+    "latest_report_noop": null,
+    "expired": null,
+    "latest_report_noop_pending": null,
+    "report_timestamp": null,
+    "certname": "client3.test.net",
+    "catalog_timestamp": null,
+    "latest_report_status": null
   }
 ]

--- a/spec/files/client9.json
+++ b/spec/files/client9.json
@@ -1,0 +1,17 @@
+{
+  "deactivated": null,
+  "latest_report_hash": null,
+  "facts_environment": "test",
+  "cached_catalog_status": null,
+  "report_environment": null,
+  "latest_report_corrective_change": null,
+  "catalog_environment": "test",
+  "facts_timestamp": "2016-10-23T15:30:52.840Z",
+  "latest_report_noop": null,
+  "expired": null,
+  "latest_report_noop_pending": null,
+  "report_timestamp": null,
+  "certname": "client9.test.net",
+  "catalog_timestamp": "2016-10-23T17:31:13.600Z",
+  "latest_report_status": "failed"
+}

--- a/spec/files/puppet.json
+++ b/spec/files/puppet.json
@@ -1,0 +1,17 @@
+{
+  "deactivated": null,
+  "latest_report_hash": null,
+  "facts_environment": "production",
+  "cached_catalog_status": null,
+  "report_environment": null,
+  "latest_report_corrective_change": null,
+  "catalog_environment": "production",
+  "facts_timestamp": "2016-10-24T16:57:09.487Z",
+  "latest_report_noop": null,
+  "expired": null,
+  "latest_report_noop_pending": null,
+  "report_timestamp": null,
+  "certname": "puppet.test.net",
+  "catalog_timestamp": "2016-10-24T16:57:36.320Z",
+  "latest_report_status": "changed"
+}


### PR DESCRIPTION
Fixed 2 bugs
- puppetlast fails when the catalogue_timestamp is nil.
- puppetlast does not actually sort when the -s command line
  option is specified.

Added a few unit more unit tests for puppetlast.