### PR TITLE
(SIMP-3421) Fix RPM auto-dependency

### DIFF
--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.0.3
+Version: 6.0.4
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -60,6 +60,11 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+
+* Wed Oct 04 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0-4-0
+- Fixed an incorrect dependency on /bin/ruby as opposed to /usr/bin/ruby
+- Changed all instances of #!/usr/bin/env ruby to #!/usr/bin/ruby per the
+  Fedora packaging guidelines
 
 * Tue Oct 03 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.3-0
 - Fixed bug in which puppetlast sort options were not working.

--- a/scripts/bin/set_environment
+++ b/scripts/bin/set_environment
@@ -1,4 +1,4 @@
-#!/bin/ruby
+#!/usr/bin/ruby
 #
 # This is a YAML-based node classifier which can be used as a Puppet
 # External Node Classifier (ENC). It identifies the environment for

--- a/scripts/sbin/hiera_upgrade
+++ b/scripts/sbin/hiera_upgrade
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 
 # This script is intended to assist users in upgrading from the SIMP fork of
 # Hiera to the latest Puppet Labs supported release.

--- a/scripts/sbin/migrate_to_simplib
+++ b/scripts/sbin/migrate_to_simplib
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 
 # This script is intended to assist users in upgrading their modules and hieradata
 # from the using `common` and `functions` module.

--- a/scripts/sbin/updaterepos
+++ b/scripts/sbin/updaterepos
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 
 # This class shamelessly borrowed from
 # http://www.software-testing.com.au/blog/2010/01/13/text-based-progress-bar-in-ruby-for-command-line-programs/

--- a/share/ldifs/convert_to_inetorg.rb
+++ b/share/ldifs/convert_to_inetorg.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 
 # A script to convert a all users in a running LDAP instance over to
 # InetOrgPerson entries.


### PR DESCRIPTION
* Fixed an incorrect dependency on /bin/ruby as opposed to /usr/bin/ruby
* Changed all instances of #!/usr/bin/env ruby to #!/usr/bin/ruby per
  the Fedora packaging guidelines

SIMP-3421 #comment Fix simp-utils RPM auto-dependency