### PR TITLE
(SIMP-4081) Recommend UID/GID above 1000

### DIFF
--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.1.0
+Version: 6.1.1
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -58,6 +58,8 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 27 2017 Nick Markowski <nicholas.markowski@onyxpoint.com> - 6.1.1-0
+- Sample LDIFS recommend UID/GID above 1000
 
 * Wed Oct 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
 - Added script to upgrade SIMP 6.0.0 to SIMP 6.1.0

--- a/share/ldifs/add_user_no_password.ldif
+++ b/share/ldifs/add_user_no_password.ldif
@@ -4,7 +4,7 @@ dn: cn=<username>,ou=Group,dc=your,dc=domain
 objectClass: posixGroup
 objectClass: top
 cn: <username>
-gidNumber: <Unique GID Number>
+gidNumber: <unique GID number above 1000>
 description: "<Group Description>"
 
 dn: uid=<username>,ou=People,dc=your,dc=domain
@@ -20,6 +20,6 @@ objectClass: shadowAccount
 objectClass: ldapPublicKey
 sshPublicKey: <some SSH public key>
 loginShell: /bin/bash
-uidNumber: <some UID number above 500>
-gidNumber: <GID number from above>
+uidNumber: <UID number above 1000>
+gidNumber: <GID number above 1000>
 homeDirectory: /home/<username>

--- a/share/ldifs/add_user_no_password.ldif
+++ b/share/ldifs/add_user_no_password.ldif
@@ -21,5 +21,5 @@ objectClass: ldapPublicKey
 sshPublicKey: <some SSH public key>
 loginShell: /bin/bash
 uidNumber: <UID number above 1000>
-gidNumber: <GID number above 1000>
+gidNumber: <gidNumber from Group entry>
 homeDirectory: /home/<username>

--- a/share/ldifs/add_user_with_password.ldif
+++ b/share/ldifs/add_user_with_password.ldif
@@ -4,7 +4,7 @@ dn: cn=<username>,ou=Group,dc=your,dc=domain
 objectClass: posixGroup
 objectClass: top
 cn: <username>
-gidNumber: <Unique GID Number>
+gidNumber: <unique GID number above 1000>
 description: "<Group Description>"
 
 dn: uid=<username>,ou=People,dc=your,dc=domain
@@ -24,8 +24,8 @@ shadowWarning: 7
 shadowLastChange: 10701
 sshPublicKey: <some SSH public key>
 loginShell: /bin/bash
-uidNumber: <some UID number above 500>
-gidNumber: <some GID number above 500>
+uidNumber: <UID number above 1000>
+gidNumber: <GID number above 1000>
 homeDirectory: /home/<username>
 userPassword: <slappasswd generated SSHA hash>
 pwdReset: TRUE

--- a/share/ldifs/add_user_with_password.ldif
+++ b/share/ldifs/add_user_with_password.ldif
@@ -25,7 +25,7 @@ shadowLastChange: 10701
 sshPublicKey: <some SSH public key>
 loginShell: /bin/bash
 uidNumber: <UID number above 1000>
-gidNumber: <GID number above 1000>
+gidNumber: <gidNumber from Group entry>
 homeDirectory: /home/<username>
 userPassword: <slappasswd generated SSHA hash>
 pwdReset: TRUE


### PR DESCRIPTION
- Users should have UIDs and GIDs above 1000
- Associated user groups should follow suit

SIMP-4081 #close