### PR TITLE
(SIMP-5378) updaterepos fails on CentOS6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,13 @@ group :test do
   gem 'mocha'
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'travish'
-  gem 'puppet-blacksmith'
-  gem 'guard-rake'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10.8', '< 2.0'])
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,6 @@ require 'rake/packagetask'
 require 'simp/rake'
 require 'simp/rake/beaker'
 
-RSpec::Core::RakeTask.new(:spec)
-
-
 # coverage/ contains SimpleCov results
 CLEAN.include 'coverage'
 

--- a/build/package_metadata.yaml
+++ b/build/package_metadata.yaml
@@ -1,5 +1,0 @@
----
-# This RPM is required by the main SIMP RPM
-optional: false
-valid_versions:
- - '5\.(1|0).*'

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.1.1
+Version: 6.1.2
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -58,6 +58,10 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+* Thu Sep 20 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.2-0
+- Fixed bug in which updaterepos would fail when executed with Ruby 1.8.x
+  (e.g on CentOS 6 servers)
+
 * Mon Nov 27 2017 Nick Markowski <nicholas.markowski@onyxpoint.com> - 6.1.1-0
 - Sample LDIFS recommend UID/GID above 1000
 

--- a/scripts/sbin/updaterepos
+++ b/scripts/sbin/updaterepos
@@ -75,12 +75,16 @@ Dir.chdir(tgt_dir) {
 
         File.umask(0022)
         %x{/usr/bin/createrepo -p --update .}
+        result = $?
         File.umask(0027)
 
         FileUtils.chown_R('root','apache', 'repodata')
-        FileUtils.chmod_R('g+srX','repodata')
+# TODO The line below does not work on Ruby 1.8 (CentOS6).  Re-enable
+#      it when we drop support for CentOS6.
+#        FileUtils.chmod_R('g+srX','repodata')
+       %x[/bin/chmod -R g+srX #{File.join(tgt_dir, dir, 'repodata')}]
 
-        if $? != 0 then
+        if result != 0 then
           $stderr.puts("Warning: There was an error running createrepo on #{tgt_dir}/#{dir}")
         end
       }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,32 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
+HOSTS:
+  el6:
+    roles:
+      - server
+      - default
+      - master
+      - client
+    platform: el-6-x86_64
+    box: centos/6
+    hypervisor: <%= hypervisor %>
+  el7:
+    roles:
+      - client
+    platform: el-7-x86_64
+    box: centos/7
+    hypervisor: <%= hypervisor %>
+
+CONFIG:
+  log_level: verbose
+  synced_folder : disabled
+  type: aio
+  vagrant_memsize: 256
+<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
+  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% end -%>

--- a/spec/acceptance/suites/default/updaterepos_spec.rb
+++ b/spec/acceptance/suites/default/updaterepos_spec.rb
@@ -1,0 +1,152 @@
+require 'spec_helper_acceptance'
+
+# Repository helper methods stolen from simp-core/spec/spec_helper_rpm.rb
+def set_up_repo(host)
+  reponame = ENV['BEAKER_repo']
+  reponame ||= '6_X'
+  if reponame[0] == '/'
+    copy_repo(host,reponame)
+  else
+    internet_simprepo(host, reponame)
+  end
+end
+
+# Install the packagecloud yum repos
+# See https://packagecloud.io/simp-project/ for the reponame key
+def internet_simprepo(host, reponame)
+  on(host, "curl -s https://packagecloud.io/install/repositories/simp-project/#{reponame}/script.rpm.sh | bash")
+  on(host, "curl -s https://packagecloud.io/install/repositories/simp-project/#{reponame}_Dependencies/script.rpm.sh | bash")
+end
+
+def copy_repo(host,reponame)
+  if File.exists?(reponame)
+    scp_to(hosts,reponame,'/etc/yum.repos.d/simp_manual.repo')
+  else
+    fail("File #{reponame} could not be found")
+  end
+end
+
+def repo_dir(repo)
+  "/var/www/yum/#{repo}"
+end
+
+def set_up_local_repo(host, repo_name)
+   repo_spec = <<EOM
+[#{repo_name}-local-x86_64]
+name=#{repo_name} local repo
+baseurl=file://#{repo_dir(repo_name)}/x86_64
+enabled=1
+gpgcheck=0
+EOM
+   repo_file = File.join('/', 'etc','yum.repos.d', "#{repo_name}_local.repo")
+   create_remote_file(host, repo_file, repo_spec)
+end
+
+shared_examples_for 'a YUM repo updater' do |host, repo, command|
+  context "#{repo_dir(repo)} does not exist" do
+    it "updaterepos should fail to update the #{repo} YUM repo" do
+      on(host, command, :acceptable_exit_codes => [1])
+    end
+  end
+
+  context "#{repo_dir(repo)} does exist" do
+    it 'should set up local repositories' do
+      set_up_local_repo(host, repo)
+    end
+
+    it "should set up #{repo_dir(repo)}" do
+      on(host, "mkdir -p #{repo_dir(repo)}/noarch #{repo_dir(repo)}/x86_64")
+      on(host, "cp /root/staging/noarch/* #{repo_dir(repo)}/noarch")
+      on(host, "cp /root/staging/x86_64/* #{repo_dir(repo)}/x86_64")
+    end
+
+    it "updaterepos should update the #{repo} YUM repo" do
+      on(host, command, :pty => true )
+      on(host, 'yum makecache')
+      (noarch_rpms + x86_64_rpms).each do |pkg|
+        result = on(host, "yum provides -C #{pkg}")
+        expect(result.stdout).to match(/^Repo\s*:\s*#{repo}\-local\-x86_64/)
+      end
+    end
+
+    it 'updaterepos should provide links of noarch RPMs' do
+      noarch_rpms.each do |pkg|
+        info = on(host, "ls -al #{repo_dir(repo)}/x86_64/#{pkg}*.rpm").stdout.strip
+        expect(info).to match(/lrwxrwxrwx.*\s+\->\s+\.\.\/noarch\/#{Regexp.escape(pkg)}/)
+      end
+    end
+
+    it 'updaterepos should allow apache group access to repodata' do
+      info = on(host, "ls -ld #{repo_dir(repo)}/x86_64/repodata").stdout.strip
+      expect(info).to match(/^drwxr\-[xs].*root\s+apache/)
+      info = on(host, "ls -l #{repo_dir(repo)}/x86_64/repodata/").stdout.strip
+      info.split("\n").each do |file_info|
+        next if file_info.match(/^total/)
+        expect(file_info).to match(/^.rw.r\-..*root\s+apache/)
+      end
+    end
+
+    it 'updaterepos should be safely re-run' do
+      on(host, command, :pty => true )
+    end
+  end
+end
+
+
+test_name 'updaterepos unit test'
+
+describe 'updaterepos unit test' do
+
+  hosts.each do |host|
+    let(:noarch_rpms) { [
+      'pupmod-puppetlabs-stdlib',
+      'pupmod-simp-simplib',
+      'simp-adapter'
+    ] }
+
+    let(:x86_64_rpms) { [
+      'sudosh2',
+      'chkrootkit'
+    ] }
+
+    context 'setup' do
+      it 'should set up common test files' do
+        scp_to(host, 'scripts/sbin/updaterepos', '/root/updaterepos')
+        on(host, 'chmod +x /root/updaterepos')
+      end
+
+      it 'should set up remote repositories' do
+        host.install_package('epel-release')
+        host.install_package('createrepo')
+        host.install_package('yum-utils')
+        host.install_package('httpd')
+        set_up_repo(host)
+        on(host, 'yum makecache')
+      end
+
+      it 'should download but not install packages' do
+        on(host, 'mkdir -p /root/staging/noarch')
+        noarch_rpms.each do |pkg|
+          on(host, "cd /root/staging/noarch; yumdownloader #{pkg}")
+        end
+
+        on(host, 'mkdir -p /root/staging/x86_64')
+        x86_64_rpms.each do |pkg|
+          on(host, "cd /root/staging/x86_64; yumdownloader #{pkg}")
+        end
+      end
+
+    end
+
+    context 'updaterepos operation' do
+
+      context 'with no arguments' do
+        it_behaves_like('a YUM repo updater', host, 'SIMP', '/root/updaterepos')
+      end
+
+      context 'with a directory command line argument' do
+        it_behaves_like('a YUM repo updater', host, 'OTHER', '/root/updaterepos /var/www/yum/OTHER')
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,20 @@
+require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Facter for beaker helpers (which uses 'facter' as
+    # part of the host setup) and some of the tests
+    host.install_package('rubygems')
+    on(host, 'gem install facter')
+    on(host, 'echo export PATH=$PATH:/usr/local/bin > /root/.bashrc')
+  end
+end
+
+RSpec.configure do |c|
+  # Readable test descriptions
+  c.formatter = :documentation
+end


### PR DESCRIPTION
- Fixed bug in which updaterepos would not run with Ruby 1.8.7,
  the native Ruby on CentOS6
- Added a test for updaterepos