### PR TITLE
(SIMP-8490) Add check stage to Travis CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
 # SIMP 6.4      5.5      2.4    TBD
-# PE 2018.1     5.5      2.4    2020-11 (LTS)
-# PE 2019.2     6.10     2.5    2019-08 (STS)
+# PE 2018.1     5.5      2.4    2021-01 (LTS)
+# PE 2019.2     6.18     2.5    2022-12 (LTS)
 #
 # https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
@@ -84,6 +84,15 @@ stages:
 
 jobs:
   include:
+    - stage: check
+      rvm: 2.4.4
+      env: PUPPET_VERSION="~> 5.5"
+      script:
+        # The puppet gem is used by one of the scripts in this
+        # project, but puppet module checks are inapplicable
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
+
     - stage: spec
       rvm: 2.4.9
       name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
@@ -99,9 +108,9 @@ jobs:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Puppet 6.10 (PE 2019.2)'
+      name: 'Puppet 6.18 (PE 2019.2)'
       rvm: 2.5.7
-      env: PUPPET_VERSION="~> 6.10.0"
+      env: PUPPET_VERSION="~> 6.18.0"
       script:
         - bundle exec rake spec
 

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.2.3
+Version: 6.3.0
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -59,6 +59,16 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+* Tue Oct 13 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.3.0-0
+- Added (optional) `--unpack-pxe [DIR]` option to the `unpack_dvd` script
+  - Added (optional) `--environment ENV` to set the PXE rsync environment
+  - Added a new `--[no-]unpack-yum` (enabled by default), to permit users to
+    disable the RPM unpack
+  - To enable unpacking PXE tftpboot files, run with `--unpack-pxe`
+  - To disable unpacking RPMs/yum repos, run with `--no-unpack-yum`
+  - See `unpack_dvd --help` for details
+- Overhauled `unpack_dvd --help`; output now fits on 80-character PTY consoles
+
 * Thu Jul 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.3-0
 - Add spec tests for unpack_dvd
 - Fix minor bugs identified unpack_dvd during testing


### PR DESCRIPTION
This patch (re-)introduces the `check` stage to simp-utils' Travis CI
pipeline, which re-enables the CHANGELOG validation tasks.

[SIMP-8490] #close


[SIMP-8490]: https://simp-project.atlassian.net/browse/SIMP-8490