### PR TITLE
(SIMP-8610) unpack_dvd safeguards OS version

### DIFF
--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.3.0
+Version: 6.4.0
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -61,11 +61,11 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 %changelog
 * Wed Oct 21 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.4.0-0
 - Added check for dangerously unspecific OS versions in `unpack_dvd`
-  (e.g., '7' instead of '7.0.2003').  This is common when autodetecting OS
-  version from the ISO's .treeinfo on some OSes (partiicularly CentOS).
-  - When detected, script will exit with an informative message + instructions
-  - In this case, users should provide a more specific version with `-v`
-  - Users can explicitly specify an unspecific version with `-v`
+  (e.g., '7' instead of '7.0.2003').  This is common when autodetecting the OS
+  version from the ISO's .treeinfo on some OSes (particularly CentOS).
+  - When detected, script will exit with an informative message + instructions.
+  - In this case, users should provide a more specific version with `-v`.
+  - Users can explicitly specify an unspecific version with `-v`.
 
 * Tue Oct 13 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.3.0-0
 - Added (optional) `--unpack-pxe [DIR]` option to the `unpack_dvd` script

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -59,6 +59,14 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+* Wed Oct 21 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.4.0-0
+- Added check for dangerously unspecific OS versions in `unpack_dvd`
+  (e.g., '7' instead of '7.0.2003').  This is common when autodetecting OS
+  version from the ISO's .treeinfo on some OSes (partiicularly CentOS).
+  - When detected, script will exit with an informative message + instructions
+  - In this case, users should provide a more specific version with `-v`
+  - Users can explicitly specify an unspecific version with `-v`
+
 * Tue Oct 13 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.3.0-0
 - Added (optional) `--unpack-pxe [DIR]` option to the `unpack_dvd` script
   - Added (optional) `--environment ENV` to set the PXE rsync environment

--- a/scripts/bin/unpack_dvd
+++ b/scripts/bin/unpack_dvd
@@ -339,6 +339,46 @@ def unpack_pxeboot_from_iso(discattrs, versiondir, isoinfo, options)
   puts "Unpacking PXE boot image files complete."
 end
 
+def fail_on_unspecific_versiondir(versiondir, options, discattrs)
+  if versiondir.split('.').size <= 1
+    if options[:version] == versiondir
+       warn <<~MSG
+         WARNING: unspecific versioned directory name ('#{versiondir}'),
+                 (Allowing because it was passed in by option)
+
+       MSG
+       return
+    end
+
+    puts <<~MSG
+  ERROR:
+
+  The versioned directory name ('#{versiondir}') this script is configured to unpack into
+  is not specific enough to be safe; if used, this ISO\'s data may overwrite/be
+  overwritten by other unpacked ISOs.
+
+  Specific release versions must contain at least one dot (.) character.
+
+  The version '#{versiondir}' may have been automatically determined from the ISO\'s
+  metadata; some OS distributions (CentOS) only provide the major OS release
+  version in their ISOs\' metadata.
+
+  WORKAROUND:
+
+  Run this script again with `-v` and specify a more specific version.  For
+  instance, when unpacking  ISO CentOS-7-x86_64-DVD-2003.iso, you could run:
+
+     unpack_dvd -v 7.0.2003 CentOS-7-x86_64-DVD-2003.iso
+
+  This would use '7.0.2003' as the specific versioned directory name to unpack
+  into, and point the major release directory name '7' to  '7.0.2003'
+  (auto-linking can be disabled with `-n`).
+
+  MSG
+    exit 1
+  end
+end
+
 # Set defaults
 options = {
   verbose: false,
@@ -452,7 +492,7 @@ end
 opt_parser.parse!
 
 # Option checking
-fail("ERROR: You must specify an ISO to unpack\n\n#{opts}") if (ARGV.length < 1)
+fail("ERROR: You must specify an ISO to unpack") if (ARGV.length < 1)
 fail("ERROR: Could not detect a package destination directory, and no --dest option provided") unless options[:dest]
 fail("ERROR: Destination directory '#{options[:dest]}' does not exist") unless File.directory?(options[:dest])
 
@@ -513,6 +553,8 @@ if options[:verbose]
   puts bnr + 'discattrs:', discattrs.to_yaml, ''
   puts bnr + "versiondir: #{versiondir}", ''
 end
+
+fail_on_unspecific_versiondir(versiondir,options,discattrs)
 
 if options[:actions][:unpack_yum_repo]
   unpack_and_create_yum_repo_from_iso(discattrs, versiondir, isoinfo, options)

--- a/scripts/bin/unpack_dvd
+++ b/scripts/bin/unpack_dvd
@@ -96,6 +96,29 @@ def bnr
   ('='*4) + ' '
 end
 
+# Extract the .treeinfo file from the disc and parse out the relevant values.
+#
+# FIXME: This should really parse as an .ini instead of naively grepping lines.
+def parse_treeinfo_into_discattrs(text)
+  discattrs = {}
+  text.each_line do |line|
+    if line =~ /^family = (.*)$/
+        fam = $1.chomp
+        if fam.chomp =~ /CentOS/
+          discattrs[:family] = "CentOS"
+        elsif fam.chomp =~ /Red Hat|RHEL|RedHat/
+          discattrs[:family] = "RedHat"
+        end
+    elsif line =~ /^version = (.*)$/
+      discattrs[:version] = $1.chomp
+    elsif line =~ /^arch = (.*)$/
+      discattrs[:arch] = $1.chomp
+    end
+  end
+  discattrs
+end
+
+
 def update_yum_repo(repo, group)
   repo_dirs = [ repo ]
 
@@ -144,20 +167,20 @@ def update_yum_repo(repo, group)
       begin
           FileUtils.chown_R('root',group, dir)
       rescue Exception => e
-        $stderr.puts("Warning: Could not change permissions on #{dir} to root:#{group}.")
+        $stderr.puts("WARNING: Could not change permissions on #{dir} to root:#{group}.")
         $stderr.puts(e)
       end
 
       begin
         FileUtils.chmod_R('g+rX',dir)
       rescue Exception => e
-        $stderr.puts("Warning: Could not change permissions on #{dir} to 'g+rX'.")
+        $stderr.puts("WARNING: Could not change permissions on #{dir} to 'g+rX'.")
         $stderr.puts(e)
       end
       begin
         FileUtils.chmod('g+s',dir)
       rescue Exception => e
-        $stderr.puts("Warning: Could  not set group id permission on #{dir} 'g+s'.")
+        $stderr.puts("WARNING: Could  not set group id permission on #{dir} 'g+s'.")
         $stderr.puts(e)
       end
     }
@@ -403,7 +426,6 @@ opt_parser = OptionParser.new do |opts|
   opts.separator 'Basic unpack options:'
   opts.separator ''
 
-
   opts.on("-v", "--version VERSION",
     "Override OS version from the ISO's .treeinfo",
     "  file (which is often just the major OS",
@@ -507,12 +529,12 @@ discattrs = {
 
 discattrs[:path] = ARGV.first
 if not File.readable?(discattrs[:path])
-  $stderr.puts("Error: Could not read file #{discattrs[:path]}")
+  $stderr.puts("ERROR: Could not read file #{discattrs[:path]}")
   exit 1
 end
 
 if File.directory?(discattrs[:path])
-  $stderr.puts("Error: #{discattrs[:path]} is a directory...")
+  $stderr.puts("ERROR: #{discattrs[:path]} is a directory...")
   exit 1
 end
 
@@ -521,32 +543,20 @@ if File.blockdev?(discattrs[:path])
   isoinfo = "isoinfo dev=#{discattrs[:path]}"
 end
 
-# Extract the .treeinfo file from the disc and parse out the relevant values.
-%x{#{isoinfo} -R -x /.treeinfo}.each_line do |line|
-  if line =~ /^family = (.*)$/
-      fam = $1.chomp
-      if fam.chomp =~ /CentOS/
-        discattrs[:family] = "CentOS"
-      elsif fam.chomp =~ /Red Hat|RHEL|RedHat/
-        discattrs[:family] = "RedHat"
-      end
-  elsif line =~ /^version = (.*)$/
-    discattrs[:version] = $1.chomp
-  elsif line =~ /^arch = (.*)$/
-    discattrs[:arch] = $1.chomp
-  end
-end
+discattrs.merge!(parse_treeinfo_into_discattrs(%x{#{isoinfo} -R -x /.treeinfo}))
 
 # If everything isn't filled, die a slow death.
 discattrs.each_pair do |k,v|
   if v.nil?
-    $stderr.puts("Error: Was not able to find the value for #{k} in the DVD .treeinfo file.")
+    $stderr.puts("ERROR: Was not able to find the value for #{k} in the DVD .treeinfo file.")
     exit 1
   end
 end
 
 # Use the version in .treeinfo if no version has been specified"
 versiondir = options[:version] || discattrs[:version]
+
+puts "Unpacking ISO as '#{discattrs[:family]}' version '#{versiondir}'"
 
 if options[:verbose]
   puts bnr + 'options:', options.to_yaml, ''

--- a/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_7/.treeinfo
+++ b/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_7/.treeinfo
@@ -1,0 +1,79 @@
+[addon-Server-HighAvailability]
+id = HighAvailability
+name = High Availability
+packages = addons/HighAvailability
+parent = Server
+repository = addons/HighAvailability
+type = addon
+uid = Server-HighAvailability
+
+[addon-Server-ResilientStorage]
+id = ResilientStorage
+name = Resilient Storage
+packages = addons/ResilientStorage
+parent = Server
+repository = addons/ResilientStorage
+type = addon
+uid = Server-ResilientStorage
+
+[checksums]
+LiveOS/squashfs.img = sha256:158657d4ff270db50204ae70c2256ca1523ee4f3c23eeedbabc3f723b69163a2
+images/pxeboot/initrd.img = sha256:094631a67f1766688dfcf4ec1f07ab0921100878736afc3cc1b31f69e7b517a1
+images/pxeboot/upgrade.img = sha256:bc884c1b4b520e57f81f3bf43156365d9ef651a47266b21e2c3d00b09e0da46b
+images/pxeboot/vmlinuz = sha256:91052b444e73f3eebdb93d1fb1506597e96c92d8de9c1e3c3f36b07a57d0a18f
+
+[general]
+; WARNING.0 = This section provides compatibility with pre-productmd treeinfos.
+; WARNING.1 = Read productmd documentation for details about new format.
+arch = x86_64
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 7.6
+packagedir = Packages
+platforms = x86_64,xen
+repository = .
+timestamp = 1539194952
+variant = Server
+variants = Server
+version = 7.6
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[images-x86_64]
+initrd = images/pxeboot/initrd.img
+kernel = images/pxeboot/vmlinuz
+upgrade = images/pxeboot/upgrade.img
+
+[images-xen]
+initrd = images/pxeboot/initrd.img
+kernel = images/pxeboot/vmlinuz
+upgrade = images/pxeboot/upgrade.img
+
+[media]
+discnum = 1
+totaldiscs = 1
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 7.6
+
+[stage2]
+mainimage = LiveOS/squashfs.img
+
+[tree]
+arch = x86_64
+build_timestamp = 1539194952
+platforms = x86_64,xen
+variants = Server
+
+[variant-Server]
+addons = Server-HighAvailability,Server-ResilientStorage
+id = Server
+name = Server
+packages = Packages
+repository = .
+type = variant
+uid = Server
+

--- a/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_7/Packages/README
+++ b/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_7/Packages/README
@@ -1,0 +1,1 @@
+Just a stub file to let things run

--- a/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_7/images/pxeboot/dummy.img
+++ b/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_7/images/pxeboot/dummy.img
@@ -1,0 +1,1 @@
+Just a stub file to let things run

--- a/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_8/.treeinfo
+++ b/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_8/.treeinfo
@@ -1,0 +1,67 @@
+[checksums]
+images/efiboot.img = sha256:94d5500c4ba266ce77b06aa955d9041eea22129737badc6af56c283dcaec1c29
+images/install.img = sha256:46171146377610cfa0deae157bbcc4ea146b3995c9b0c58d9f261ce404468abe
+images/pxeboot/initrd.img = sha256:e0cd3966097c175d3aaf406a7f8c094374c69504c7be8f08d8084ab9a8812796
+images/pxeboot/vmlinuz = sha256:370db9a3943d4f46dc079dbaeb7e0cc3910dca069f7eede66d3d7d0d5177f684
+
+[general]
+; WARNING.0 = This section provides compatibility with pre-productmd treeinfos.
+; WARNING.1 = Read productmd documentation for details about new format.
+arch = x86_64
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 8.0.0
+packagedir = AppStream/Packages
+platforms = x86_64,xen
+repository = AppStream
+timestamp = 1554367044
+variant = AppStream
+variants = AppStream,BaseOS
+version = 8.0.0
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[images-x86_64]
+efiboot.img = images/efiboot.img
+initrd = images/pxeboot/initrd.img
+kernel = images/pxeboot/vmlinuz
+
+[images-xen]
+initrd = images/pxeboot/initrd.img
+kernel = images/pxeboot/vmlinuz
+
+[media]
+discnum = 1
+totaldiscs = 1
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 8.0.0
+
+[stage2]
+mainimage = images/install.img
+
+[tree]
+arch = x86_64
+build_timestamp = 1554367044
+platforms = x86_64,xen
+variants = AppStream,BaseOS
+
+[variant-AppStream]
+id = AppStream
+name = AppStream
+packages = AppStream/Packages
+repository = AppStream
+type = variant
+uid = AppStream
+
+[variant-BaseOS]
+id = BaseOS
+name = BaseOS
+packages = BaseOS/Packages
+repository = BaseOS
+type = variant
+uid = BaseOS
+

--- a/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_8/Packages/README
+++ b/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_8/Packages/README
@@ -1,0 +1,1 @@
+Just a stub file to let things run

--- a/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_8/images/pxeboot/dummy.img
+++ b/spec/scripts/bin/files/unpack_dvd/ISO/RedHat_8/images/pxeboot/dummy.img
@@ -1,0 +1,1 @@
+Just a stub file to let things run


### PR DESCRIPTION
This patch adds a check for dangerously unspecific OS versions (e.g., '7'
instead of '7.0.2003') to the `unpack_dvd` script.

This is common when autodetecting OS version from the ISO's .treeinfo on some
OSes (partiicularly CentOS), and results in clobbering older / getting clobbered
by newer ISO unpacks from the same major OS version.

- When detected, script will exit with an informative message + instructions
- In this case, users should provide a more specific version with `-v`
- Users can still force a dangerously unspecific version with `-v`

The spec tests have been updated to accommodate the new behavior,
and now mock RHEL 7 and 8 ISOs in addition to the CentOS ISOs, to test
ISOs that provide both specific and dangerously unspecific OS versions.

[SIMP-8611] #close
[SIMP-8622] #comment prep work: moved .treeinfo logic into method

[SIMP-8611]: https://simp-project.atlassian.net/browse/SIMP-8611
[SIMP-8622]: https://simp-project.atlassian.net/browse/SIMP-8622