### PR TITLE
(SIMP-8347) Restore correct version logic in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@
 #   Travis CI Env Var      Type      Notes
 #   ---------------------  --------  -------------------------------------------
 #   GITHUB_OAUTH_TOKEN     Secure    Required for automated GitHub releases
-#   PUPPETFORGE_API_TOKEN  Secure    Required for automated Forge releases
 #   SKIP_GITHUB_PUBLISH    Optional  Skips publishing GitHub releases if "true"
-#   SKIP_FORGE_PUBLISH     Optional  Skips publishing to Puppet Forge if "true"
 #
 #   The secure env vars will be filtered in Travis CI log output, and aren't
 #   provided to untrusted builds (i.e, triggered by PR from another repository)
@@ -35,11 +33,12 @@
 #
 # Release Engineering notes:
 #
-#   To automagically publish a release to GitHub and PuppetForge:
+#   To automagically publish a release to GitHub:
 #
-#   - Set GITHUB_OAUTH_TOKEN and PUPPETFORGE_API_TOKEN as secure env variables
+#   - Set GITHUB_OAUTH_TOKEN as secure env variables
 #     in this repo's Travis CI settings
-#   - Push a git tag that matches the version in the module's `metadata.json`
+#   - Push a git tag that matches the version in the component's
+#     `build/<component>.spec`
 #   - The tag SHOULD be annotated with release notes, but nothing enforces this
 #     convention at present
 #
@@ -120,19 +119,9 @@ jobs:
       script:
         - true
       before_deploy:
-        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-        - 'gem install -v "~> 5.5.0" puppet'
-        - 'git clean -f -x -d'
-        - 'puppet module build'
-        - 'find pkg -name ''*.tar.gz'''
+        - "export SPECFILE_VERSION=`rpm -q --specfile build/*.spec --queryformat '%{VERSION}'`"
+        - '[[ $TRAVIS_TAG =~ ^${SPECFILE_VERSION}$ ]]'
       deploy:
-        - provider: script
-          skip_cleanup: true
-          script: 'curl -sS --fail -A "$FORGE_USER_AGENT" -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN}" -X POST -F "file=@$(find $PWD/pkg -name ''*.tar.gz'')" https://forgeapi.puppet.com/v3/releases'
-          on:
-            tags: true
-            condition: '($SKIP_FORGE_PUBLISH != true)'
         - provider: releases
           token: $GITHUB_OAUTH_TOKEN
           on:
@@ -150,14 +139,3 @@ jobs:
       - 'curl -H "Authorization: token ${GITHUB_OAUTH_TOKEN}"
           "https://api.github.com/users/$OWNER"
           -I | grep ^X-OAuth-Scopes | egrep -w "repo|public_repo"'
-
-    - stage: 'validate tokens'
-      name:  'validate CI Puppet Forge token authenticates with API'
-      language: shell
-      before_install: skip
-      install: skip
-      script:
-      - 'echo; echo "===== PUPPETFORGE_API_TOKEN validation"; echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
-      - 'curl -sS --fail -A "$FORGE_USER_AGENT"
-         -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN:-default_content_to_cause_401_response}"
-         https://forgeapi.puppet.com/v3/users > /dev/null'


### PR DESCRIPTION
At some point, the .travis.yml file was modified to contain the
latest release logic for Puppet modules. This PR reverts the
version logic to be appropriate for this non-Puppet-module asset
and removes PuppetForge-related logic.

SIMP-8347 #close