### PR TITLE
SIMP-8488 Unpack SIMP to OS spec directories

### DIFF
--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -61,6 +61,11 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+* Thu Apr 29 2021 Jeanne Greulich <jeanne.greulichr@onyxpoint.com> - 6.5.1-1
+- Update unpack DVD to extract the SIMP repo into
+  <destination dir>/SIMP/<os family>/<os version>/ and create the link
+  to the major version if it is requested.
+
 * Mon Mar 01 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.5.1-1
 - Changed shebang in convert_to_inetorg.rb to use Puppet's Ruby instead
   of system Ruby.

--- a/scripts/bin/unpack_dvd
+++ b/scripts/bin/unpack_dvd
@@ -19,8 +19,9 @@
 #
 # When unpacking RPMs:
 #
-#  * The script creates the relevant OS directory (i.e., `RedHat/7.5/x86_64/`)
-#    and a `SIMP/` directory under the yum directory root.
+#  * The script creates the relevant OS directory  (i.e., `RedHat/7.5/x86_64/`)
+#    and a`SIMP` directory with the relevant OS information (i.e., `SIMP/RedHat/7.5/x86_64/`)
+#    under the yum directory root.
 #
 #  * Any files under the `SIMP/` directory on the ISO are unpacked to the local
 #    `SIMP/` directory; all other files are unpacked under the OS directory.
@@ -247,7 +248,7 @@ def unpack_and_create_yum_repo_from_iso(discattrs, versiondir, isoinfo, options)
   kill_dirs = iso_toc.map{ |x| File.dirname( x ) }.uniq
   iso_toc   = iso_toc - kill_dirs
   destdir   = "#{options[:dest]}/#{discattrs[:family]}/#{versiondir}/#{discattrs[:arch]}/"
-  simpdir   = "#{options[:dest]}/SIMP/#{discattrs[:arch]}/"
+  simpdir   = "#{options[:dest]}/SIMP/#{discattrs[:family]}/#{versiondir}/#{discattrs[:arch]}/"
 
   progress  = ProgressBar.new(iso_toc.size)
 
@@ -281,8 +282,12 @@ def unpack_and_create_yum_repo_from_iso(discattrs, versiondir, isoinfo, options)
   puts "Yum repo creation complete"
 
   if options[:create_major_os_symlink]
-    target_basedir = File.join(options[:dest], discattrs[:family])
     maj_versiondir = discattrs[:version].split('.').first
+    # create major link for OS repository
+    target_basedir = File.join(options[:dest], discattrs[:family])
+    create_major_os_version_symlink(target_basedir, versiondir, maj_versiondir)
+    # create major link for SIMP repository
+    target_basedir = File.join(options[:dest],'SIMP',discattrs[:family])
     create_major_os_version_symlink(target_basedir, versiondir, maj_versiondir)
   end
 


### PR DESCRIPTION
- When unpacking the DVD place any simp files in
  <destination>/SIMP/<os name>/<os version>/<arch>.  This will allow
  users to extract SIMP for multiple OS on the yum server.

SIMP-8488 #comment Update unpack_dvd