### PR TITLE
(SIMP-10415) Honor build/rpm_metadata/requires

### DIFF
--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -44,7 +44,7 @@ end
 Summary: SIMP Utils
 Name: simp-utils
 Version: 6.5.1
-Release: %{lua: print(package_release)}%{?dist}
+Release: %{lua: print(package_release)}
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,6 +1,6 @@
 %{lua:
 --
--- When buildng the RPM, declare macro 'pup_module_info_dir' with the path to
+-- When building the RPM, declare macro 'pup_module_info_dir' with the path to
 -- the top-level project directory.  This directory should contain the
 -- following items:
 --   * 'build' directory

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -1,7 +1,50 @@
+%{lua:
+--
+-- When buildng the RPM, declare macro 'pup_module_info_dir' with the path to
+-- the top-level project directory.  This directory should contain the
+-- following items:
+--   * 'build' directory
+--   * 'README.md' file
+--
+package_release = '1'
+local potential_src_dirs = {
+  rpm.expand('%{pup_module_info_dir}'),
+  rpm.expand('%{_sourcedir}'),
+  posix.getcwd(),
+}
+local src_dir = "\0"
+
+for _k,dir in pairs(potential_src_dirs) do
+  if (posix.stat(dir .. '/build', 'type') == 'directory') and (posix.stat(dir .. '/README.md', 'type') == 'regular') then
+    src_dir = dir
+    break
+  end
+end
+
+if src_dir == "\0" then
+  error(
+    "FATAL: Cannot determine RPM project's src_dir!\n" ..
+    "\t* Paths tried: '" .. table.concat(potential_src_dirs, "', '") .."\n" ..
+    "\t* PROTIP: Declare macro %pup_module_info_dir\n"
+  )
+end
+
+-- Snag the RPM-specific items out of the 'build/rpm_metadata' directory
+rel_file = (io.open(src_dir .. "/build/rpm_metadata/release", "r") or io.open(src_dir .. "/release", "r"))
+if rel_file then
+  for line in rel_file:lines() do
+    if not (line:match("^%s*#") or line:match("^%s*$")) then
+      package_release = line
+      break
+    end
+  end
+end
+}
+
 Summary: SIMP Utils
 Name: simp-utils
 Version: 6.5.1
-Release: 1
+Release: %{lua: print(package_release)}%{?dist}
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz


### PR DESCRIPTION
Before this patch, the project's RPM .spec file used a hard-coded
`Release:` number that could not be overridden by the optional
`build/rpm_metadata/release` file used by other projects.  

This patch adds support for `build/rpm_metadata/release`, and defaults
to the standard `-1` Release value.

[SIMP-10415] #comment Update simp-utils
[SIMP-10417] #close

[SIMP-10415]: https://simp-project.atlassian.net/browse/SIMP-10415
[SIMP-10417]: https://simp-project.atlassian.net/browse/SIMP-10417