### PR TITLE
Add GCP support to GLCI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,8 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5.7   2022-12 (LTS)
+# PE 2019.8     6.28     2.5.7   2023-07 (LTS)
+# PE 2021.7     7.20     2.7.6   TBD (LTS)
 ---
 
 stages:
@@ -34,20 +35,16 @@ variables:
   BUNDLE_BIN:        .vendor/gem_install/bin
   BUNDLE_NO_PRUNE:   'true'
 
+.snippets:
+  before_beaker_google:
+    # Logic for beaker-google environments
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script05[collapsed=true]\r\e[0KGCP environment checks"
+    - "if [ \"$BEAKER_HYPERVISOR\" ==  google ]; then mkdir -p ~/.ssh; chmod 700 ~/.ssh; test -f ~/.ssh/google_compute_engine || ssh-keygen -f ~/.ssh/google_compute_engine < /dev/null; echo 'gem \"beaker-google\"' >> Gemfile.local ; fi"
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script05\r\e[0K"
 
-# bundler dependencies and caching
-#
-# - Cache bundler gems between pipelines foreach Ruby version
-# - Try to use cached and local resources before downloading dependencies
-# --------------------------------------
-.setup_bundler_env: &setup_bundler_env
-  cache:
-    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
-    paths:
-      - '.vendor'
-  before_script:
+  before:
     # Print important environment variables that may affect this job
-    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
+    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX|GOOGLE/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
 
     - echo -e "\e[0Ksection_start:`date +%s`:before_script10[collapsed=true]\r\e[0KDiagnostic ruby & gem information"
     # Diagnostic ruby & gem information
@@ -87,6 +84,19 @@ variables:
     - 'bundle show sync || :'
     - 'bundle exec gem list sync || :'
     - echo -e "\e[0Ksection_end:`date +%s`:before_script40\r\e[0K"
+
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
+.setup_bundler_env: &setup_bundler_env
+  cache:
+    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
+    paths:
+      - '.vendor'
+  before_script:
+    !reference [.snippets, before]
 
 
 # Assign a matrix level when your test will run.  Heavier jobs get higher numbers
@@ -233,6 +243,8 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet7'
     MATRIX_RUBY_VERSION: '2.7'
 
+
+
 # Testing Environments
 #-----------------------------------------------------------------------
 
@@ -246,11 +258,28 @@ variables:
     - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm-build; fi ||:'
     - 'bundle exec rake spec'
 
+.beaker: &beaker
+  image: ruby:2.7.2  # must be 2.7.2 if running in GCP
+  tags:
+    - beaker
+  before_script:
+    - !reference [.snippets, before_beaker_google]
+    - !reference [.snippets, before]
+
+
+
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
-  tags: ['beaker']
   <<: *setup_bundler_env
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  <<: *beaker
+
+.compliance_base: &compliance_base
+  stage: 'compliance'
+  <<: *setup_bundler_env
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  <<: *beaker
+
 
 # Pipeline / testing matrix
 #=======================================================================


### PR DESCRIPTION
This patch updates GHA workflows to use GCP as a hypervisor when
BEAKER_HYPERVISOR is `google`

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.