### PR TITLE
Updates for Puppet 8

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: |
           bundle show
@@ -43,7 +43,7 @@ jobs:
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - name: 'Tags and changelogs'
@@ -61,6 +61,9 @@ jobs:
           - label: 'Puppet 7.x'
             puppet_version: '~> 7.0'
             ruby_version: '2.7'
+          - label: 'Puppet 8.x'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.2'
     env:
       PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
     steps:

--- a/build/simp-utils.spec
+++ b/build/simp-utils.spec
@@ -43,7 +43,7 @@ end
 
 Summary: SIMP Utils
 Name: simp-utils
-Version: 6.7.2
+Version: 6.8.0
 Release: %{lua: print(package_release)}%{?dist}
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -113,6 +113,13 @@ chmod -R u=rwx,g=rx,o=rx %{buildroot}/usr/local/*bin
 # Post uninstall stuff
 
 %changelog
+* Tue Jul 16 2024 Steven Pritchard <steve@sicura.us> - 6.8.0-1
+- Updates for Puppet 8
+    - Various fixes for Ruby 3 compatibility
+    - Fix use of legacy facts
+    - Use Ruby 2.7 (Puppet 7) for GHA tests by default
+    - Add Ruby 3.2/Puppet 8 to GHA test matrix
+
 * Thu Oct 28 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.7.2-1
 -  EL8 client kickstart config fixes:
    - Removed krb5-workstation and subversion from the list of required packages

--- a/scripts/bin/unpack_dvd
+++ b/scripts/bin/unpack_dvd
@@ -124,7 +124,7 @@ def update_yum_repo(repo, group)
   repo_dirs = [ repo ]
 
   puts "Updating repo at #{repo}"
-  FileUtils.mkdir_p(repo,{:mode => 0755})
+  FileUtils.mkdir_p(repo, mode: 0o755)
   Dir.chdir(repo) do
     discovered_repos = Dir.glob(File.join('..', '**', 'repomd.xml'))
     discovered_repos.map! do |x|
@@ -214,7 +214,7 @@ def sort_noarch(dir, arch)
 #  directory.
 #
   noarchdir = File.expand_path("../noarch", dir )
-  FileUtils.mkdir_p(noarchdir, {:mode => 0755})
+  FileUtils.mkdir_p(noarchdir, mode: 0o755)
   Dir.chdir(dir) do
     Dir.glob('*.rpm').each do |rpmfile|
       next if File.symlink?(rpmfile)
@@ -248,7 +248,7 @@ def get_iso_toc(isoinfo)
 end
 
 def create_major_os_version_symlink(target_basedir, versiondir, maj_versiondir)
-  FileUtils.mkdir_p(target_basedir, {:mode => 0755})
+  FileUtils.mkdir_p(target_basedir, mode: 0o755)
 
   Dir.chdir(target_basedir) do
     if maj_versiondir != versiondir

--- a/scripts/sbin/puppetlast
+++ b/scripts/sbin/puppetlast
@@ -274,7 +274,7 @@ class PuppetLast
           begin
             require 'puppet'
 
-            transaction_report = YAML.load_file(latest_report)
+            transaction_report = YAML.safe_load(File.read(latest_report), permitted_classes: [Puppet::Transaction::Report])
 
             unless (hosts.empty? || hosts.include?(transaction_report.host))
               @logger.debug("Skipping #{transaction_report.host} since it is not in the host list")

--- a/spec/acceptance/suites/default/00_gen_ldap_update_spec.rb
+++ b/spec/acceptance/suites/default/00_gen_ldap_update_spec.rb
@@ -88,7 +88,7 @@ describe 'gen-ldap-update unit test' do
 
     context 'when no ldap configuration is present' do
       let(:host_base_dn) {
-        fact_on(host, 'domain').split('.').map{ |d| "dc=#{d}" }.join(',')
+        fact_on(host, 'networking.domain').split('.').map{ |d| "dc=#{d}" }.join(',')
       }
 
       it 'should remove old ldap.conf files' do
@@ -104,7 +104,7 @@ describe 'gen-ldap-update unit test' do
       # FIXME This is hack that wouldn't be necessary if gen-ldap-update used
       # the domain fact?
       it 'should fix hostname' do
-        fqdn = fact_on(host,'fqdn').strip
+        fqdn = fact_on(host,'networking.fqdn').strip
         hostname = on(host, 'hostname').stdout.strip
         if fqdn != hostname
           on(host, "hostname #{fqdn}")

--- a/spec/acceptance/suites/default/10_updaterepos_spec.rb
+++ b/spec/acceptance/suites/default/10_updaterepos_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper_acceptance'
 #
 # @fails if the specified repo file cannot be installed on host
 def copy_repo(host, repo_filename, repo_name = 'simp_manual.repo')
-  if File.exists?(repo_filename)
+  if File.exist?(repo_filename)
     puts('='*72)
     puts("Using repos defined in #{repo_filename}")
     puts('='*72)
@@ -135,7 +135,7 @@ test_name 'updaterepos unit test'
 describe 'updaterepos unit test' do
 
   hosts.each do |host|
-    os_major = fact_on(host, 'operatingsystemmajrelease')
+    os_major = fact_on(host, 'os.release.major')
     if os_major == '8'
       puts 'SKIPPING test because SIMP repositories for EL8 are not set up: SIMP-9143'
       next

--- a/spec/acceptance/suites/default/20_openldap_to_389ds_spec.rb
+++ b/spec/acceptance/suites/default/20_openldap_to_389ds_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 describe 'OpenLDAP to 389DS convert and import scripts' do
 
   ldap_server = only_host_with_role(hosts, 'ldap_server')
-  ldap_server_fqdn = fact_on(ldap_server, 'fqdn')
+  ldap_server_fqdn = fact_on(ldap_server, 'networking.fqdn')
 
   let(:files_dir) { File.join(File.dirname(__FILE__), 'files', 'openldap_to_389ds') }
   let(:scripts_src) { 'share/transition_scripts/openldap_to_389ds' }
@@ -135,8 +135,8 @@ describe 'OpenLDAP to 389DS convert and import scripts' do
       'simp_options::trusted_nets'               => ['any'],
       'simp_options::pki'                        => true,
       'simp_options::pki::source'                => '/etc/pki/simp-testing/pki',
-      'pki::private_key_source'                  => '/etc/pki/simp-testing/pki/private/%{facts.fqdn}.pem',
-      'pki::public_key_source'                   => '/etc/pki/simp-testing/pki/public/%{facts.fqdn}.pub',
+      'pki::private_key_source'                  => '/etc/pki/simp-testing/pki/private/%{facts.networking.fqdn}.pem',
+      'pki::public_key_source'                   => '/etc/pki/simp-testing/pki/public/%{facts.networking.fqdn}.pub',
       'pki::cacerts_sources'                     => [ '/etc/pki/simp-testing/pki/cacerts'],
       'simp_options::ldap'                       => true,
       'simp_options::ldap::uri'                  => [ "ldaps://#{ldap_server_fqdn}" ],

--- a/spec/scripts/bin/unpack_dvd_spec.rb
+++ b/spec/scripts/bin/unpack_dvd_spec.rb
@@ -33,6 +33,7 @@ describe 'unpack_dvd script' do
     'mkisofs',
     'isoinfo',
     'rpmbuild',
+    'createrepo',
   ]
   require 'facter'
   missing_apps = required_apps.select{|x| !Facter::Core::Execution.which(x)}


### PR DESCRIPTION
* Various fixes for Ruby 3 compatibility
* Fix use of legacy facts
* Use Ruby 2.7 (Puppet 7) for GHA tests by default
* Add Ruby 3.2/Puppet 8 to GHA test matrix
* Avoid tests that require createrepo when it is not available

Fixes #56